### PR TITLE
setup.cfg: fix README file extension

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = ansible-automation-platform-billing
 summary = Ansible Automation Platform billing connector
 description-file =
-    README.rst
+    README.md
 author = Ansible, Inc.
 author-email = info@ansible.com
 python-requires = >=3.8


### PR DESCRIPTION
After renaming the README file in a51b134c it's not possible to build the python package with pbr because the setup.cfg file is still referencing the old README file.