### PR TITLE
AAP-8781 followup, remove token from log

### DIFF
--- a/aap_billing/azure/storage.py
+++ b/aap_billing/azure/storage.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import requests
+import sys
 
 
 def fetchBaseQuantity(url, token, offer_id, plan_id):
@@ -7,7 +9,13 @@ def fetchBaseQuantity(url, token, offer_id, plan_id):
     Get file from Azure storage at given URL and parse to get base quantity for offer/plan
     """
     url = url + "?" + token
+    # Temporarily disable URL logging to hide token
+    urlLogger = logging.getLogger("urllib3")
+    urlLogger.disabled = True
     res = requests.get(url)
+
+    # Reenable logging
+    urlLogger.disabled = False
     if res.status_code == 200:
         offers_plans = json.loads(res.content)
         for offer in offers_plans["offers"]:
@@ -16,5 +24,6 @@ def fetchBaseQuantity(url, token, offer_id, plan_id):
                     if plan["id"] == plan_id:
                         return plan["base_quantity"]
     else:
-        res.raise_for_status()
+        print(f"Failed to fetch billing config file!  Status code: {res.status_code}")
+        sys.exit(1)
     return None

--- a/aap_billing/azure/storage.py
+++ b/aap_billing/azure/storage.py
@@ -10,12 +10,11 @@ def fetchBaseQuantity(url, token, offer_id, plan_id):
     """
     url = url + "?" + token
     # Temporarily disable URL logging to hide token
-    urlLogger = logging.getLogger("urllib3")
-    urlLogger.disabled = True
+    logging.disable(logging.DEBUG)
     res = requests.get(url)
 
     # Reenable logging
-    urlLogger.disabled = False
+    logging.disable(logging.NOTSET)
     if res.status_code == 200:
         offers_plans = json.loads(res.content)
         for offer in offers_plans["offers"]:

--- a/aap_billing/settings.py
+++ b/aap_billing/settings.py
@@ -47,9 +47,9 @@ DIMENSION = "managed_active_node"
 Import /etc/billing/billingconf.py settings file if it exists.
 Database settings are expected to be defined there.
 Plan json file also expected:
-PLAN_CONFIG_URL, points to plans.json containing offer and plan base
+PLAN_CONFIG_URL, points to config file containing offer and plan base
                  quantity details
-PLAN_STORAGE_TOKEN, used to fetch plans.json from PLAN_CONFIG_URL
+PLAN_STORAGE_TOKEN, used to fetch config file from PLAN_CONFIG_URL
 """
 
 DATABASES = {}


### PR DESCRIPTION
Temporarily disable logging for URLs so we don't expose the token and remove references to plans.json file.