### PR TITLE
Fix billing error for non-marketplace deployments

### DIFF
--- a/aap_billing/azure/azapi.py
+++ b/aap_billing/azure/azapi.py
@@ -146,11 +146,10 @@ def _fetchManagedAppMetadata(managed_app_id, access_token):
         managed_app_api_version,
     )
     j = _getJsonPayload(url, auth_header, "resource usage ID and plan")
-    metadata["kind"] = j["kind"]
-    metadata["plan_id"] = j["plan"]["name"]
-    metadata["offer_id"] = _stripPreviewSuffix(j["plan"]["product"])
-    if "billingDetails" in j["properties"]:
-        metadata["resource_id"] = j["properties"]["billingDetails"]["resourceUsageId"]
+    metadata["kind"] = j["kind"]  # Always present
+    metadata["plan_id"] = j["plan"]["name"] if "plan" in j else None
+    metadata["offer_id"] = _stripPreviewSuffix(j["plan"]["product"]) if "plan" in j else None
+    metadata["resource_id"] = j["properties"]["billingDetails"]["resourceUsageId"] if "billingDetails" in j["properties"] else None
     logger.debug("Fetched managed app metadata info: %s)" % metadata)
     return metadata
 
@@ -185,22 +184,6 @@ def pegBillingCounter(dimension, hosts):
     Send usage quantity to billing API
     """
     metadata = getManAppIdAndMetadata()
-    if metadata["kind"] != "MarketPlace":
-        logger.info(
-            """
-            Billing is not active/functional in single tenant deployments
-            """
-        )
-        sys.exit(0)
-    if "resource_id" not in metadata:
-        logger.error(
-            """
-            No billing details present on managed app metadata.
-            Check offer/plan billing configuration.  If billing
-            is configured properly, report this error.
-            """
-        )
-        sys.exit(1)
     billing_data = {}
     billing_data["resourceId"] = metadata["resource_id"]
     billing_data["dimension"] = dimension

--- a/aap_billing/cli.py
+++ b/aap_billing/cli.py
@@ -39,6 +39,25 @@ def determineBaseQuantity(offer_id, plan_id):
     return base_quantity
 
 
+def exitIfNotMarketplaceDeployment(metadata):
+    if metadata["kind"] != "MarketPlace":
+        logger.info(
+            """
+            Billing is not active/functional in single tenant deployments
+            """
+        )
+        sys.exit(0)
+    if "resource_id" not in metadata:
+        logger.error(
+            """
+            No billing details present on managed app metadata.
+            Check offer/plan billing configuration.  If billing
+            is configured properly, report this error.
+            """
+        )
+        sys.exit(1)
+
+
 # Main
 def main():
     args = processArgs()
@@ -79,6 +98,9 @@ def main():
             # Azure
             # Get offer/plan from metadata
             metadata = azapi.getManAppIdAndMetadata()
+            # Ensure Marketplace deployment with billing data
+            exitIfNotMarketplaceDeployment(metadata)
+
             offer_id = metadata["offer_id"]
             plan_id = metadata["plan_id"]
             base_quantity = determineBaseQuantity(offer_id, plan_id)


### PR DESCRIPTION
Fix for Azure pod errors when billing executes on non-marketplace deployments.

No Jira for this, just noticed it was happening.

To test if desired:

Deploy using create.sh script.  Run the demo template at least once to create a host execution to "bill".

Connect to AKS.

Create a pod:

```
apiVersion: v1
kind: Pod
metadata:
  name: billing-test
  namespace: ansible-automation-platform-billing
  labels:
    azure.workload.identity/use: "true"
spec:
  containers:
  - name: billing
    image: quay.io/bhavenst/billing:latest
    command: ["/usr/bin/tail", "-f", "/dev/null"]
    volumeMounts:
    - mountPath: /etc/billing/billingconf.py
      name: billing-settings
      readOnly: true
      subPath: billingconf.py
  volumes:
  - name: billing-settings
    secret:
      defaultMode: 420
      secretName: billing-settings
```

Exec into container and execute "aap-billing -d".  The process should end nicely with a message printed and $? should be 0.

