### PR TITLE
Remove warning for audit, add audit command line

### DIFF
--- a/aap_billing/utils/audit_billing.py
+++ b/aap_billing/utils/audit_billing.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-from datetime import datetime
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
-from django.utils import timezone
 
 import argparse
 import csv

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ python-requires = >=3.8
 console_scripts =
     aap-billing = aap_billing.cli:main
     aap-billing-manage = aap_billing.manage:main
+    aap-billing-audit = aap_billing.utils.audit_billing:main
 
 [files]
 packages =


### PR DESCRIPTION
One more small update before the new version.  Add "aap-billing-audit" command line for audit (now they just run the script with the full path) and remove a python/django warning from the audit output.