### PR TITLE
AAP-43467: Ignore ansible_host when dict

### DIFF
--- a/aap_billing/azure/azapi.py
+++ b/aap_billing/azure/azapi.py
@@ -141,7 +141,7 @@ def getManAppIdAndMetadata():
     Grab various info from metadata
     """
     global metadata_loaded
-    global metadata
+    global metadata  # noqa: F824
 
     if metadata_loaded:
         return metadata

--- a/aap_billing/db/db.py
+++ b/aap_billing/db/db.py
@@ -186,11 +186,17 @@ def deduplicateHosts(host_list):
                 variables = json.loads(defined_hosts_vars[executed_host])
             except json.JSONDecodeError:
                 logger.error("Unable to parse vars for %s as json, giving up", executed_host)
+
+        # Default to executed_host unless a valid ansible_host is found
+        final_host_key = executed_host
         if variables is not None and "ansible_host" in variables:
-            # Add to filtered list with ansible_host value instead of hostname
-            deduped_hosts[variables["ansible_host"]] = host_list[executed_host]
-        else:
-            deduped_hosts[executed_host] = host_list[executed_host]
+            ansible_host_value = variables["ansible_host"]
+            # Only use ansible_host if it's not a dict
+            if not isinstance(ansible_host_value, dict):
+                final_host_key = ansible_host_value
+
+        deduped_hosts[final_host_key] = host_list[executed_host]
+
     return deduped_hosts
 
 

--- a/aap_billing/db/db.py
+++ b/aap_billing/db/db.py
@@ -187,12 +187,11 @@ def deduplicateHosts(host_list):
             except json.JSONDecodeError:
                 logger.error("Unable to parse vars for %s as json, giving up", executed_host)
 
-        # Default to executed_host unless a valid ansible_host is found
+        # Default to executed_host unless ansible_host is a valid string
         final_host_key = executed_host
-        if variables is not None and "ansible_host" in variables:
-            ansible_host_value = variables["ansible_host"]
-            # Only use ansible_host if it's not a dict
-            if not isinstance(ansible_host_value, dict):
+        if variables is not None:
+            ansible_host_value = variables.get("ansible_host")
+            if isinstance(ansible_host_value, str):
                 final_host_key = ansible_host_value
 
         deduped_hosts[final_host_key] = host_list[executed_host]

--- a/aap_billing/tests/test_billing.py
+++ b/aap_billing/tests/test_billing.py
@@ -77,12 +77,12 @@ class BillingTests(TransactionTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(BillingTests, cls).setUpClass()
-
         # Create unmanaged job host summary table
         with connection.schema_editor() as schema_editor:
             schema_editor.create_model(JobHostSummary)
             schema_editor.create_model(Host)
+
+        super(BillingTests, cls).setUpClass()
 
     @mock.patch("requests.get", side_effect=mocked_azure_apis)
     @mock.patch("requests.post", side_effect=mocked_azure_apis)


### PR DESCRIPTION
Jira:  https://issues.redhat.com/browse/AAP-43467

Change to ignore the ansible_host var if the return is a dict and fall back to using the inventory_hostname.

Problem:
All billing jobs will fail when ansible_host returns dict:
```
Traceback (most recent call last):
  File "/usr/bin/aap-billing", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.11/site-packages/aap_billing/cli.py", line 76, in main
    unbilled = db.getUnbilledHosts(period_start)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/aap_billing/db/db.py", line 151, in getUnbilledHosts
    host_list = deduplicateHosts(executed_hosts)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/aap_billing/db/db.py", line 191, in deduplicateHosts
    deduped_hosts[variables["ansible_host"]] = host_list[executed_host]
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unhashable type: 'dict'
```
 